### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,5 +1,7 @@
 ---
 name: Linter
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/szpaczyna/rpi-k3s/security/code-scanning/7](https://github.com/szpaczyna/rpi-k3s/security/code-scanning/7)

To fix the problem, add a `permissions` block to the workflow file. The best way is to add it at the top level (just after the `name:` key and before `on:`), so it applies to all jobs in the workflow. Since the jobs only need to read repository contents, set `permissions: contents: read`. This change does not affect the existing functionality of the workflow, as none of the jobs require write access or special permissions.

**What to change:**  
- Edit `.github/workflows/lint.yml`.
- Insert the following block after the `name: Linter` line (line 2), before the `on:` block:
  ```yaml
  permissions:
    contents: read
  ```
- No new methods, imports, or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
