### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/readme_append.yml
+++ b/.github/workflows/readme_append.yml
@@ -8,6 +8,8 @@ on:
 
 jobs:
   README:
+    permissions:
+      contents: write
     runs-on: ubuntu-latest
     steps:
     - name: GitHub README Generator


### PR DESCRIPTION
Potential fix for [https://github.com/szpaczyna/rpi-k3s/security/code-scanning/3](https://github.com/szpaczyna/rpi-k3s/security/code-scanning/3)

To fix the problem, you should add a `permissions` block to the workflow or to the specific job. The block should grant only the minimum permissions required for the workflow to function. Since the action used (`th3c0d3br34ker/github-readme-info@1.0.2`) likely needs to push changes to the repository (i.e., update the README), it will require `contents: write` permission. The best practice is to add the `permissions` block at the job level (under `README:`), but it can also be added at the workflow root if all jobs require the same permissions. In this case, add the following under the job definition (line 11), before `runs-on`:  
```yaml
permissions:
  contents: write
```
No additional imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
